### PR TITLE
Fix Thread.exclusive deprecation in Ruby 2.3.0

### DIFF
--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -60,6 +60,7 @@ class Progress
     @total = total
     @current = 0.0
     @title = title
+    @mutex = Mutex.new
   end
 
   def to_f(inner)
@@ -77,7 +78,7 @@ class Progress
     @step = step
     @note = note
     ret = yield if block_given?
-    Thread.exclusive do
+    @mutex.synchronize do
       @current += step
     end
     ret
@@ -87,7 +88,7 @@ class Progress
     @step = new_current - @current
     @note = note
     ret = yield if block_given?
-    Thread.exclusive do
+    @mutex.synchronize do
       @current = new_current
     end
     ret


### PR DESCRIPTION
`Thread.exclusive` is deprecated since Ruby 2.3.0. 
Calling this method generates a lot of error messages in console as below:

```
Thread.exclusive is deprecated, use Mutex
```

This PR fixes this issue.