### PR TITLE
Update bundler before TravisCI builds

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/CyclomaticComplexity:
 Metrics/MethodLength:
   Max: 20
 
+Metrics/ModuleLength:
+  Max: 160
+
 Metrics/PerceivedComplexity:
   Max: 10
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: ruby
+before_install:
+  - gem update bundler
 rvm:
   - 1.8.7
   - 1.9.2
   - 1.9.3
-  - '2.0'
-  - '2.1'
+  - 2.0
+  - 2.1
+  - 2.2
   - jruby-18mode
   - jruby-19mode
   - ree

--- a/lib/progress.rb
+++ b/lib/progress.rb
@@ -70,7 +70,8 @@ class Progress
 
   def step(step, note)
     unless step.is_a?(Numeric)
-      step, note = nil, step
+      note = step
+      step = nil
     end
     step = 1 if step.nil?
 

--- a/lib/progress/class_methods.rb
+++ b/lib/progress/class_methods.rb
@@ -176,7 +176,7 @@ class Progress
       if terminal_title?
         out << "\e]0;"
         unless options[:finish]
-          out << message.gsub(/\e\[\dm/, '').gsub("\a", '␇')
+          out << message.gsub(/\e\[\dm/, '').tr("\a", '␇')
         end
         out << "\a"
       end

--- a/lib/progress/with_progress.rb
+++ b/lib/progress/with_progress.rb
@@ -15,7 +15,9 @@ class Progress
     # initialize with object responding to each, title and optional length
     # if block is provided, it is passed to each
     def initialize(enum, title = nil, length = nil)
-      @enum, @title, @length = enum, title, length
+      @enum = enum
+      @title = title
+      @length = length
     end
 
     # returns self but changes title


### PR DESCRIPTION
Latest builds on travis are broken because of bundler is too old and contains some issues

- Refs: travis-ci/travis-ci#3531

And this PR will fix [this build](https://travis-ci.org/toy/progress/builds/99130969).