### PR TITLE
Support Enumerable#each_with_index

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 before_install:
   - gem update bundler
 rvm:
-  - '1.8.7-p371'
   - '1.9.3-p551'
   - '2.0.0-p648'
   - '2.1.10'

--- a/lib/progress/with_progress.rb
+++ b/lib/progress/with_progress.rb
@@ -105,9 +105,9 @@ class Progress
 
     def run_with_length(enum, length, method, *args)
       Progress.start(@title, length) do
-        enum.send(method, *args) do |block_args|
+        enum.send(method, *args) do |*block_args|
           Progress.step do
-            yield(block_args)
+            yield(*block_args)
           end
         end
       end
@@ -116,9 +116,9 @@ class Progress
     def run_with_pos(io, method, *args)
       size = io.respond_to?(:size) ? io.size : io.stat.size
       Progress.start(@title, size) do
-        io.send(method, *args) do |block_args|
+        io.send(method, *args) do |*block_args|
           Progress.set(io.pos) do
-            yield(block_args)
+            yield(*block_args)
           end
         end
       end

--- a/spec/progress_spec.rb
+++ b/spec/progress_spec.rb
@@ -95,6 +95,17 @@ describe Progress do
           expect{ reference.next }.to raise_error(StopIteration)
         end
 
+        it 'does not break each_with_index' do
+          reference = enum.each
+          counter = 0
+          enum.with_progress.each_with_index do |n, i|
+            expect(n).to eq(reference.next)
+            expect(i).to eq(counter)
+            counter += 1
+          end
+          expect{ reference.next }.to raise_error(StopIteration)
+        end
+
         it 'does not break find' do
           default = proc{ 'default' }
           expect(enum.with_progress.find{ |n| n == 100 }).


### PR DESCRIPTION
It used to work correctly, but does not work in recent gems since 45435b31ae0f9ad42255d9105d264f5fe9722c88.

I suppose this causes SyntaxError on Ruby < 1.9, but do we really still have to support Ruby 1.8?
I'm sorry I couldn't come up with any good solution to support both `each_with_index` and Ruby 1.8. So, I'd propose dropping Ruby 1.8 support, and bring `each_with_index` support back.