### PR TITLE
Support Enumerable#each_with_index (take 2)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,9 @@ Metrics/ModuleLength:
 Metrics/PerceivedComplexity:
   Max: 10
 
+Performance/RedundantBlockCall:
+  Enabled: false
+
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 

--- a/lib/progress/with_progress.rb
+++ b/lib/progress/with_progress.rb
@@ -103,22 +103,22 @@ class Progress
       end
     end
 
-    def run_with_length(enum, length, method, *args)
+    def run_with_length(enum, length, method, *args, &block)
       Progress.start(@title, length) do
-        enum.send(method, *args) do |block_args|
+        enum.send(method, *args) do |*block_args|
           Progress.step do
-            yield(block_args)
+            block.call(*block_args)
           end
         end
       end
     end
 
-    def run_with_pos(io, method, *args)
+    def run_with_pos(io, method, *args, &block)
       size = io.respond_to?(:size) ? io.size : io.stat.size
       Progress.start(@title, size) do
-        io.send(method, *args) do |block_args|
+        io.send(method, *args) do |*block_args|
           Progress.set(io.pos) do
-            yield(block_args)
+            block.call(*block_args)
           end
         end
       end

--- a/spec/progress_spec.rb
+++ b/spec/progress_spec.rb
@@ -95,6 +95,17 @@ describe Progress do
           expect{ reference.next }.to raise_error(StopIteration)
         end
 
+        it 'does not break each_with_index' do
+          reference = enum.each
+          counter = 0
+          enum.with_progress.each_with_index do |n, i|
+            expect(n).to eq(reference.next)
+            expect(i).to eq(counter)
+            counter += 1
+          end
+          expect{ reference.next }.to raise_error(StopIteration)
+        end
+
         it 'does not break find' do
           default = proc{ 'default' }
           expect(enum.with_progress.find{ |n| n == 100 }).


### PR DESCRIPTION
Here's a patch that rewrites some `yield` calls to `block.call` in order to bring `each_with_index` support back as discussed on https://github.com/toy/progress/pull/9#issuecomment-333313564.

It's true that there can be a never observable very little performance regression in micro-benchmarks level, but I'm sure we do not at all have to care about that here.